### PR TITLE
PKG-4697: Fix aarch64 package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
-!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-# we want a noarch package for linux, and one for win.
-noarch_upload: [linux-64, win-64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,14 +11,13 @@ source:
   sha256: e2c71babfd18a8e69542dd7e9ca018f9caa438094001a58e6bc4d8c999bf0d07
 
 build:
-  number: 0
-  noarch: generic
+  number: 1
   skip: true # [osx or (linux and s390x)]
 
 requirements:
   run:
-    - __linux  # [linux]
-    - __win    # [win]
+    #- __linux  # [linux]
+    #- __win    # [win]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - binutils   # [linux]


### PR DESCRIPTION
The noarch package with __linux dependency pulled in the {{ compiler() }} for linux-64, since it was built on that platform.

We don't have a generic, platform-independent `c-compiler` package which is resolved at time of package use. So we can't make this a noarch package.

Bumping the build number in addition, and removing the abs.yaml configuration addressing noarch package upload.

**Destination channel:** defaults