### PR TITLE
cuda-compiler v13.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,7 +3,8 @@ build_parameters:
   #- "--skip-existing"
   - "--error-overlinking"
 
-staging_channel_upload_target: ctk-13.1.1-build-1
+staging_channel_upload_target: ctk-13.1.1-build-2
 
 channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-2
   - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - cuda-nvcc 13.1.80
     - cuda-nvprune 13.1.80
     - cuda-ctadvisor 13.1.80
+    - cuda-tileiras 13.1.80
 
 test:
   commands:
@@ -34,6 +35,7 @@ test:
     - {{ exists }} nvcc
     - {{ exists }} nvprune
     - {{ exists }} ctadvisor
+    - {{ exists }} tileiras
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.0.2" %}
+{% set version = "13.1.0" %}
 {% set exists = "" %}  # [not (linux or win)]
 {% set exists = "which" %}  # [linux]
 {% set exists = "where" %}  # [win]
@@ -21,11 +21,11 @@ requirements:
     - __win    # [win]
     - c-compiler
     - cxx-compiler
-    - cuda-cuobjdump 13.0.85
-    - cuda-cuxxfilt 13.0.85
-    - cuda-nvcc 13.0.88
-    - cuda-nvprune 13.0.85
-    - cuda-ctadvisor 13.0.85
+    - cuda-cuobjdump 13.1.80
+    - cuda-cuxxfilt 13.1.80
+    - cuda-nvcc 13.1.80
+    - cuda-nvprune 13.1.80
+    - cuda-ctadvisor 13.1.80
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "13.1.0" %}
+{% set version = "13.1.1" %}
 {% set exists = "" %}  # [not (linux or win)]
 {% set exists = "which" %}  # [linux]
 {% set exists = "where" %}  # [win]
@@ -21,11 +21,11 @@ requirements:
     - __win    # [win]
     - c-compiler
     - cxx-compiler
-    - cuda-cuobjdump 13.1.80
-    - cuda-cuxxfilt 13.1.80
-    - cuda-nvcc 13.1.80
-    - cuda-nvprune 13.1.80
-    - cuda-ctadvisor 13.1.80
+    - cuda-cuobjdump 13.1.115
+    - cuda-cuxxfilt 13.1.115
+    - cuda-nvcc 13.1.115
+    - cuda-nvprune 13.1.115
+    - cuda-ctadvisor 13.1.115
     - cuda-tileiras 13.1.80
 
 test:


### PR DESCRIPTION
cuda-compiler 13.1.1

**Destination channel:** defaults

### Links

- [PKG-12032](https://anaconda.atlassian.net/browse/PKG-12032) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cuda-tileiras-feedstock/pull/1

### Explanation of changes:

- CUDA 13.1 release


[PKG-12032]: https://anaconda.atlassian.net/browse/PKG-12032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ